### PR TITLE
Standardize license headers in Python files

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1,4 +1,4 @@
-# Ultralytics MkDocs plugin 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 from .main import MetaPlugin
 

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -1,4 +1,4 @@
-# Ultralytics MkDocs plugin 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import json
 from pathlib import Path

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -1,4 +1,4 @@
-# Ultralytics MkDocs plugin 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 import contextlib
 import re


### PR DESCRIPTION
This PR updates all Python file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all Python files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Updated license headers across files to reference the official Ultralytics license URL.

### 📊 Key Changes
- Updated comment headers in `__init__.py`, `main.py`, and `utils.py` to point to the official Ultralytics license URL.
- Rephrased the license text to align with the official legal reference.

### 🎯 Purpose & Impact
- 🛡️ **Clarity and Consistency**: Ensures all files reference the correct license URL, making compliance straightforward and transparent.
- 🌐 **Improved Accessibility**: Users can now easily access the full license text by following the provided URL.