### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Dependabot for package version updates
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Publish pip package to PyPI https://pypi.org/project/mkdocs-ultralytics-plugin/
 
 name: Publish to PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Ultralytics MkDocs plugin 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Overview:
 # This pyproject.toml file manages the build, packaging, and distribution of the MkDocs Ultralytics Plugin.


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary  
Minor updates to license references across repository files for consistency and clarity. 🔧✨  

### 📊 Key Changes  
- Updated the license header format in `dependabot.yml`, `format.yml`, `publish.yml`, and `pyproject.toml` files to a standardized format:  
  `Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`.

### 🎯 Purpose & Impact  
- **Improved Consistency:** Unified license references across all project files for a professional and polished look.  
- **Clarity:** Added explicit license URL for easier access to licensing details.  
- **No Functional Impact:** These are documentation and metadata updates, so they won’t affect code functionality.