### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,8 @@ jobs:
     needs: [check, publish]
     if: always() && needs.check.outputs.increment == 'True'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Extract PR Details


### PR DESCRIPTION
Potential fix for [https://github.com/ultralytics/mkdocs/security/code-scanning/2](https://github.com/ultralytics/mkdocs/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `notify` job. Since the job only performs notification tasks and does not interact with the repository in a way that requires write permissions, we can set the permissions to `contents: read`. This ensures that the job has the minimal permissions required to execute its tasks securely.

The `permissions` block should be added under the `notify` job definition, specifically after the `runs-on` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved GitHub Actions workflow security for publishing documentation. 🔒🚀

### 📊 Key Changes
- Added explicit permissions (`contents: read`) to the `publish.yml` workflow job.

### 🎯 Purpose & Impact
- Enhances security by limiting workflow permissions to only what's needed.
- Reduces potential risks from overly broad access during documentation publishing.
- No impact on end users; internal improvement for safer project maintenance.