### PR TITLE
Fix plugin operation with missing `git`

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "0.1.21"
+__version__ = "0.1.22"
 
 from .main import MetaPlugin
 

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -62,7 +62,6 @@ class MetaPlugin(BasePlugin):
     copy_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"/></svg>'
     check_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41L9 16.17z"></path></svg>'
 
-
     def __init__(self):
         self.git_available = self._check_git_available()
 

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -62,9 +62,13 @@ class MetaPlugin(BasePlugin):
     copy_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"/></svg>'
     check_icon = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 16.17L4.83 12l-1.42 1.41L9 19L21 7l-1.41-1.41L9 16.17z"></path></svg>'
 
+
+    def __init__(self):
+        self.git_available = self._check_git_available()
+
     def on_config(self, config):
         """Disable authors if git unavailable."""
-        if not self._check_git_available():
+        if not self.git_available:
             self.config["add_authors"] = False
         return config
 
@@ -102,9 +106,13 @@ class MetaPlugin(BasePlugin):
         file_path = str(Path(file_path).resolve())
 
         # Get the creation and last modified dates
-        args = ["git", "log", "--reverse", "--pretty=format:%ai", file_path]
-        creation_date = check_output(args).decode("utf-8").split("\n")[0]
-        last_modified_date = check_output(["git", "log", "-1", "--pretty=format:%ai", file_path]).decode("utf-8")
+        if self.git_available:
+            args = ["git", "log", "--reverse", "--pretty=format:%ai", file_path]
+            creation_date = check_output(args).decode("utf-8").split("\n")[0]
+            last_modified_date = check_output(["git", "log", "-1", "--pretty=format:%ai", file_path]).decode("utf-8")
+        else:
+            creation_date = None
+            last_modified_date = None
         git_info = {
             "creation_date": creation_date or DEFAULT_CREATION_DATE,
             "last_modified_date": last_modified_date or DEFAULT_MODIFIED_DATE,


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved plugin stability by handling cases where Git is not available, ensuring smoother documentation builds. 🚀

### 📊 Key Changes
- Updated plugin version to 0.1.22.
- Added a check for Git availability during plugin initialization.
- Modified logic to disable author information in documentation if Git is not present.
- Ensured creation and modification dates are set to default values when Git is unavailable.

### 🎯 Purpose & Impact
- Prevents errors during documentation builds on systems without Git installed.
- Ensures documentation remains consistent and builds reliably in more environments.
- Reduces confusion by automatically disabling author features when Git data can't be accessed.