### PR TITLE
Check git `--is-inside-working-tree`

### DIFF
--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -1,6 +1,6 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
-__version__ = "0.1.23"
+__version__ = "0.1.24"
 
 from .main import MetaPlugin
 

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -64,8 +64,8 @@ class MetaPlugin(BasePlugin):
 
     def __init__(self):
         try:
-            check_output(["git", "--version"], stderr=subprocess.DEVNULL)
-            self.git_available = True
+            result = check_output(["git", "rev-parse", "--is-inside-work-tree"], stderr=subprocess.DEVNULL)
+            self.git_available = result.decode().strip() == "true"
         except (subprocess.CalledProcessError, FileNotFoundError):
             self.git_available = False
 


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Improved detection of Git repository status in the Ultralytics MkDocs plugin for more accurate functionality. 🚀

### 📊 Key Changes
- Updated the plugin version from 0.1.23 to 0.1.24.
- Changed the method for checking Git availability: now verifies if the current directory is inside a Git repository, not just if Git is installed.

### 🎯 Purpose & Impact
- Ensures the plugin only enables Git-dependent features when actually inside a Git repository, reducing errors and confusion.
- Provides a more reliable experience for users working in different environments, especially those not using Git.