### PR TITLE
Update pyproject.toml for `beautifulsoup4>=4.13.5`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ classifiers = [
 ]  # Optional, for a list of valid classifiers, see https://pypi.org/classifiers/
 dependencies = [
     "mkdocs>=1.0",
-    "beautifulsoup4>=4.13.5",  # test unpin after >=4.13.3 crashes https://github.com/ultralytics/mkdocs/issues/128
+    "beautifulsoup4>=4.13.5",  # fix 4.13.4 bug https://github.com/ultralytics/mkdocs/issues/128
     "pyyaml",
     "requests>=2.28.1",  # do not increase (conflicts in Ultralytics deps)
 ]


### PR DESCRIPTION
<!--
Thank you 🙏 for your contribution to [Ultralytics](https://www.ultralytics.com/) 🚀! Your effort in enhancing our repositories is greatly appreciated. To streamline the process and assist us in integrating your Pull Request (PR) effectively, please follow these steps:

1. Check for Existing Contributions: Before submitting, kindly explore existing PRs to ensure your contribution is unique and complementary.
2. Link Related Issues: If your PR addresses an open issue, please link it in your submission. This helps us better understand the context and impact of your contribution.
3. Elaborate Your Changes: Clearly articulate the purpose of your PR. Whether it's a bug fix or a new feature, a detailed description aids in a smoother integration process.
4. Ultralytics Contributor License Agreement (CLA): To uphold the quality and integrity of our project, we require all contributors to sign the CLA. Please confirm your agreement by commenting below:

    I have read the CLA Document and I sign the CLA

For more detailed guidance and best practices on contributing, refer to our ✅ [Contributing Guide](https://docs.ultralytics.com/help/contributing/). Your adherence to these guidelines ensures a faster and more effective review process.
-->


## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Bumps BeautifulSoup dependency to avoid a known bug and ensure smoother MkDocs builds ✅

### 📊 Key Changes
- Updated dependency: `beautifulsoup4` from `>=4.9.3,<=4.12.3` to `>=4.13.5` 🧩
- Notes a fix for a bug in `4.13.4` (see issue #128) 🔧
- Other dependencies unchanged (e.g., `requests>=2.28.1`) 📦

### 🎯 Purpose & Impact
- Prevents build and parsing issues caused by `beautifulsoup4` 4.13.4 🛠️
- Ensures compatibility and stability with newer BeautifulSoup releases going forward 🚀
- Users may need to upgrade BeautifulSoup; run: `pip install -U beautifulsoup4` 🔄
- Minimal risk: only affects environments pinned to older/buggy versions, improving reliability for docs generation ✅