### PR TITLE
Ultralytics Refactor https://ultralytics.com/actions

### DIFF
--- a/plugin/main.py
+++ b/plugin/main.py
@@ -333,9 +333,7 @@ class MetaPlugin(BasePlugin):
 
         # Add Copy for LLM button near Edit button at the top (but NOT on reference pages)
         if self.config["add_copy_llm"] and "/reference/" not in page.url:
-            # Find the edit button first
-            edit_btn = soup.find("a", {"title": "Edit this page"})
-            if edit_btn:
+            if edit_btn := soup.find("a", {"title": "Edit this page"}):
                 # Create the copy button
                 copy_button = soup.new_tag(
                     "a",


### PR DESCRIPTION
This [Ultralytics](https://www.ultralytics.com/) PR refactors code to improve performance and readability. 🔄

### Key changes include:

- 🚀 Optimized various functions for faster execution.
- 🧩 Simplified complex logic for better understanding and maintenance.
- 🗑️ Removed redundant code to streamline operations.
- 📚 Improved code structure and organization.

These changes aim to enhance the overall quality and efficiency of the code. 🌟

### Learn more about Ultralytics:

- [About Us](https://www.ultralytics.com/about) 🌐
- [Install the Ultralytics App](https://www.ultralytics.com/app-install) 📲
- [Read Our Blog](https://www.ultralytics.com/blog) 📝
- [Learn about YOLO](https://www.ultralytics.com/yolo) 🤖
- [Explore Ultralytics HUB](https://www.ultralytics.com/hub) 🚀
- [Check Out Our Plans](https://www.ultralytics.com/plans) 💼
- [Join our Team](https://www.ultralytics.com/careers) 🌾
- [AI in Healthcare](https://www.ultralytics.com/solutions/ai-in-healthcare) 🏥
- [AI in Manufacturing](https://www.ultralytics.com/solutions/ai-in-manufacturing) 🏭
- [Attend YOLO VISION 2024](https://www.ultralytics.com/events/yolovision) 📅

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary
Small refactor to how the “Copy for LLM” button is added next to the “Edit this page” button, improving code clarity without changing behavior. ✅

### 📊 Key Changes
- Replaced a two-step variable assignment and check with a single inline assignment using the walrus operator (`:=`) when finding the “Edit this page” button. 🧼
- Logic still only adds the “Copy for LLM” button on non-reference pages and only if the edit button exists. 🔗

### 🎯 Purpose & Impact
- Cleaner, more concise code that’s easier to read and maintain. ✨
- No functional changes for users; the documentation site behavior remains the same. 🛡️
- Depends on Python 3.8+ (for the walrus operator), which is already standard for most environments. 🐍