### PR TITLE
Fix default_author parameter bug from PR #177

### DIFF
--- a/plugin/main.py
+++ b/plugin/main.py
@@ -9,6 +9,7 @@ from mkdocs.plugins import BasePlugin
 
 import plugin.processor as processor
 from plugin.processor import process_html
+from plugin.utils import resolve_all_authors
 
 
 class MetaPlugin(BasePlugin):
@@ -43,6 +44,12 @@ class MetaPlugin(BasePlugin):
             docs_dir = Path(config["docs_dir"])
             md_files = [str(p) for p in docs_dir.rglob("*.md")] if docs_dir.exists() else []
             self.git_repo_url, self.git_data = processor.build_git_map(md_files)
+            self.git_data = resolve_all_authors(
+                self.git_data,
+                default_author=self.config.get("default_author"),
+                repo_url=self.git_repo_url,
+                verbose=self.config.get("verbose", True),
+            )
         return config
 
     def on_post_page(self, output: str, page, config) -> str:
@@ -69,7 +76,6 @@ class MetaPlugin(BasePlugin):
                 git_data=self.git_data,
                 repo_url=self.git_repo_url,
                 default_image=self.config["default_image"],
-                default_author=self.config["default_author"],
                 keywords=keywords,
                 add_desc=self.config["add_desc"],
                 add_image=self.config["add_image"],


### PR DESCRIPTION
## Summary
- Fix regression from PR #177 where [`default_author` was passed to `process_html()`](https://github.com/ultralytics/mkdocs/blob/3cdfd50f6cc7c004fe311d87947d03e09c858ece/plugin/main.py#L72) but that function no longer accepts it
- Align MkDocs plugin flow with `postprocess.py` by calling `resolve_all_authors()` in `on_config()`

## Problem
PR #177 removed `default_author` from `process_html()` but didn't update [`main.py`](https://github.com/ultralytics/mkdocs/blob/3cdfd50f6cc7c004fe311d87947d03e09c858ece/plugin/main.py#L72). Running mkdocs build with add_authors: true or add_json_ld: true would crash with:

```bash
TypeError: process_html() got an unexpected keyword argument 'default_author'
```

**Why ultralytics CI didn't catch this:** `build_docs.py` uses [`zensical build`](https://github.com/ultralytics/ultralytics/blob/25a773aaf3824891ea5d1ef46e60deff70d0122f/docs/build_docs.py#L630) + [direct `postprocess_site()` call](https://github.com/ultralytics/ultralytics/blob/25a773aaf3824891ea5d1ef46e60deff70d0122f/docs/build_docs.py#L641), bypassing the plugin's `on_post_page` hook where the bug occurs.

**When this matters:** If we switch back from zensical to mkdocs build, builds would fail without this fix.

## Fix
Align main.py with [postprocess.py](https://github.com/ultralytics/mkdocs/blob/198d5a840457146ad3d4a85815dddc659c61bf8d/plugin/postprocess.py#L184-L187):

1. Import `resolve_all_authors` from `plugin.utils`
2. Call `resolve_all_authors()` in `on_config()` after building git_data
3. Remove `default_author` from `process_html()` call

This is the same flow that [`postprocess.py` uses](https://github.com/ultralytics/mkdocs/blob/198d5a840457146ad3d4a85815dddc659c61bf8d/plugin/postprocess.py#L184-L187).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves author handling in the MkDocs plugin by resolving author information upfront for all pages, making metadata generation more consistent and reliable 🧑‍💻✨

### 📊 Key Changes
- Added `resolve_all_authors` import and integrated it into the plugin config setup.
- After building the Git metadata map, the plugin now resolves author data for all Markdown files during `on_config`.
- Passed new author-resolution options into this step:
  - `default_author`
  - `repo_url`
  - `verbose`
- Removed direct `default_author` handling from the later `process_html()` call, shifting author logic earlier in the pipeline.
- Kept the rest of the page-processing flow unchanged, so the update is focused specifically on metadata preparation 🔧

### 🎯 Purpose & Impact
- Improves consistency by preparing complete author metadata before pages are rendered 📚
- Reduces repeated or fragmented author-handling logic by centralizing it in one place 🧹
- Makes page post-processing simpler and cleaner, which should help maintainability for developers 🛠️
- Helps ensure pages fall back to a default author more reliably when Git author data is missing 🙌
- Likely improves debugging and transparency through the `verbose` option when resolving authors 🔍