### PR TITLE
Fix Copy button fails in Safari

### DIFF
--- a/plugin/processor.py
+++ b/plugin/processor.py
@@ -436,21 +436,22 @@ def process_html(
                 let rawUrl = editBtn.href.replace('github.com', 'raw.githubusercontent.com');
                 rawUrl = rawUrl.replace('/blob/', '/').replace('/tree/', '/');
 
-                try {{
+                async function getContent() {{
                     const response = await fetch(rawUrl);
                     let markdown = await response.text();
-
                     if (markdown.startsWith('---')) {{
                         const frontMatterEnd = markdown.indexOf('\\n---\\n', 3);
-                        if (frontMatterEnd !== -1) {{
-                            markdown = markdown.substring(frontMatterEnd + 5).trim();
-                        }}
+                        if (frontMatterEnd !== -1) markdown = markdown.substring(frontMatterEnd + 5).trim();
                     }}
-
                     const title = document.querySelector('h1')?.textContent || document.title;
-                    const content = `# ${{title}}\\n\\nSource: ${{window.location.href}}\\n\\n---\\n\\n${{markdown}}`;
+                    return `# ${{title}}\\n\\nSource: ${{window.location.href}}\\n\\n---\\n\\n${{markdown}}`;
+                }}
 
-                    await navigator.clipboard.writeText(content);
+                try {{
+                    const clipboardItem = new ClipboardItem({{
+                        'text/plain': getContent().then(text => new Blob([text], {{ type: 'text/plain' }}))
+                    }});
+                    await navigator.clipboard.write([clipboardItem]);
                     button.innerHTML = checkIcon + ' Copied!';
                     setTimeout(() => {{ button.innerHTML = originalHTML; }}, 2000);
                 }} catch (err) {{


### PR DESCRIPTION
## Summary
- The "Copy page in Markdown format" button works in Chrome, Edge, and Firefox but fails in Safari with "Failed" message
- Safari has stricter Clipboard API security that rejects writes when async operations (like `fetch`) occur before the clipboard write
- Switch from `navigator.clipboard.writeText()` to `ClipboardItem` API which reserves clipboard permission at click time while content loads asynchronously
- This approach works across all modern browsers including Safari

## Test
Tested on Safari 18 - button now shows "Copied!" and markdown content is correctly copied to clipboard.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
✨ This PR improves the docs “copy page content” feature by making clipboard copying more robust and preserving the generated Markdown content more cleanly.

### 📊 Key Changes
- Refactored the content-fetching logic into a reusable async `getContent()` function.
- Continued fetching the raw Markdown source from GitHub and stripping front matter before copying.
- Changed clipboard handling from `navigator.clipboard.writeText()` to `navigator.clipboard.write()` with a `ClipboardItem`.
- Packaged the copied output as a plain text `Blob` instead of writing a simple string directly.
- Kept the copied content format the same overall: page title, source URL, separator, and Markdown body.
- Preserved the existing success UI feedback, showing a ✅ “Copied!” state briefly after success.

### 🎯 Purpose & Impact
- ✅ **Improves clipboard compatibility:** Using `ClipboardItem` can work more reliably in modern browsers and clipboard workflows.
- 🚀 **Makes the code cleaner:** Separating content generation into `getContent()` makes the logic easier to maintain and extend.
- 📄 **Preserves useful page context:** Users still get a nicely structured Markdown copy that includes the page title and source link.
- 🛠️ **Reduces formatting issues:** Copying as a plain text blob may help avoid inconsistencies when pasting into editors, notes, or AI tools.
- 👥 **Better end-user experience:** For anyone copying docs content from the Ultralytics MkDocs site, this should make the feature feel more dependable and polished.