### PR TITLE
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python


### PR DESCRIPTION
Bump astral-sh/setup-uv from v7 to v8 in /.github/workflows/publish.yml

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions workflow to use `astral-sh/setup-uv@v8` instead of `@v7` in the package publishing process.

### 📊 Key Changes
- Upgraded the `setup-uv` GitHub Action in `.github/workflows/publish.yml` from `astral-sh/setup-uv@v7` to `astral-sh/setup-uv@v8`.
- No other workflow logic or publishing steps were changed.

### 🎯 Purpose & Impact
- Improves maintenance by keeping the CI/CD workflow aligned with the latest version of the `setup-uv` action 🚀
- May provide upstream fixes, performance improvements, or compatibility updates from the newer action version.
- Minimal user-facing impact, but helps keep automated publishing more reliable and up to date 🛠️