### PR TITLE
Bump astral-sh/setup-uv to v8 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - run: uv pip install --system --no-cache build
       - run: python -m build
       - uses: actions/upload-artifact@v7
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8
       - run: |
           uv venv sbom-env
           uv pip install -e .


### PR DESCRIPTION
Bump astral-sh/setup-uv to v8 in /.github/workflows

Automated by [Ultralytics Actions](https://github.com/ultralytics/actions).

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub Actions workflow to use `astral-sh/setup-uv@v8` instead of `@v7` in the publishing pipeline.

### 📊 Key Changes
- Upgraded the `setup-uv` GitHub Action from `v7` to `v8` in `.github/workflows/publish.yml`.
- Applied this update in all relevant publish workflow jobs:
  - package/version checking
  - build step
  - SBOM-related environment setup
- No application code or documentation logic was changed—this is a CI/CD maintenance update only. 🛠️

### 🎯 Purpose & Impact
- Keeps the repository’s release workflow aligned with the latest `uv` GitHub Action version. ✅
- Helps improve long-term workflow reliability, compatibility, and support as older action versions age out.
- Reduces maintenance risk by ensuring the publishing pipeline uses a more current dependency setup.
- Minimal user-facing impact: this mainly benefits maintainers by making package publishing and build automation more up to date and stable. 🚀