### PR TITLE
Fix invalid setup-uv action version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - run: uv pip install --system --no-cache ultralytics-actions
       - id: check_pypi
         shell: python
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - run: uv pip install --system --no-cache build
       - run: python -m build
       - uses: actions/upload-artifact@v7
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
       - run: |
           uv venv sbom-env
           uv pip install -e .


### PR DESCRIPTION
## Summary
- change `astral-sh/setup-uv` from `@v8` to `@v7` in release workflows
- fix the workflow reference to an action version that exists

## Testing
- `rg -n --hidden --no-ignore 'astral-sh/setup-uv@v8' /Users/glennjocher/PycharmProjects`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the GitHub publish workflow to use `astral-sh/setup-uv@v7` instead of `@v8`, likely to improve workflow stability and compatibility.

### 📊 Key Changes
- Replaced `astral-sh/setup-uv@v8` with `astral-sh/setup-uv@v7` in `.github/workflows/publish.yml`.
- Applied this change in all affected publish workflow jobs, including:
  - the PyPI check/install step
  - the package build step
  - the SBOM-related environment setup step
- No application code or package logic was changed; this is a CI/CD workflow-only update. 🛠️

### 🎯 Purpose & Impact
- Helps avoid issues introduced by `setup-uv@v8`, likely by reverting to a more reliable or compatible version. ✅
- Improves the consistency of automated publishing, building, and SBOM generation in GitHub Actions.
- Reduces the risk of CI failures during release workflows, which can make package publishing more dependable for maintainers. 🚀
- Since this only affects automation infrastructure, end users should not see any direct product changes.