### PR TITLE
Use Python 3.14 in format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -25,6 +25,7 @@ jobs:
         uses: ultralytics/actions@main
         with:
           token: ${{ secrets._GITHUB_TOKEN || secrets.GITHUB_TOKEN }} # Auto-generated token
+          python-version: "3.14"
           labels: true # Auto-label issues/PRs using AI
           python: true # Format Python with Ruff and docformatter
           prettier: true # Format YAML, JSON, Markdown, CSS


### PR DESCRIPTION
## Summary
- run the Ultralytics Actions formatter workflow on Python 3.14
- keep existing Python 3.14 package classifier unchanged

## Tests
- python -c "import tomllib; tomllib.load(open("pyproject.toml", "rb"))"
- actionlint .github/workflows/*.yml

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔧 This PR updates the formatting workflow to run with Python 3.14, keeping the repository’s automation aligned with newer Python versions.

### 📊 Key Changes
- Added `python-version: "3.14"` to the `.github/workflows/format.yml` workflow.
- This change applies to the `ultralytics/actions@main` step used for automated formatting and labeling.
- The rest of the workflow behavior remains the same, including:
  - AI-based PR/issue labeling
  - Python formatting with Ruff and docformatter
  - Prettier formatting for YAML, JSON, Markdown, and CSS

### 🎯 Purpose & Impact
- 🚀 Ensures the formatting pipeline is tested and executed with Python 3.14.
- 🧩 Helps keep CI automation current with the latest Python ecosystem.
- 🛠️ Reduces the risk of version-related issues in formatting or tooling as Python evolves.
- 👥 For contributors, this should mean more consistent formatting checks and better future compatibility with modern Python environments.