### PR TITLE
Improve README accuracy and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🚀 MkDocs Ultralytics Plugin
 
-Welcome to the MkDocs Ultralytics Plugin! 📄 This powerful tool enhances your [MkDocs](https://www.mkdocs.org/), [Zensical](https://zensical.com/), or any static site documentation with advanced Search Engine Optimization (SEO) features, interactive social elements, and structured data support. It automates the generation of essential meta tags, incorporates social sharing capabilities, and adds [JSON-LD](https://json-ld.org/) structured data to elevate user engagement and improve your documentation's visibility on the web.
+Welcome to the MkDocs Ultralytics Plugin! 📄 This powerful tool enhances your [MkDocs](https://www.mkdocs.org/), [Zensical](https://zensical.org/), or any static site documentation with advanced Search Engine Optimization (SEO) features, interactive social elements, and structured data support. It automates the generation of essential meta tags, incorporates social sharing capabilities, and adds [JSON-LD](https://json-ld.org/) structured data to elevate user engagement and improve your documentation's visibility on the web.
 
 **Two modes available:**
 
@@ -27,6 +27,7 @@ This tool seamlessly integrates valuable features into your documentation site:
 - **JSON-LD Support**: Adds structured data in JSON-LD format, helping search engines understand your content better and potentially enabling rich results.
 - **FAQ Parsing**: Automatically parses FAQ sections (if present) and includes them in the structured data for enhanced search visibility.
 - **Copy for LLM**: Adds a button to copy page content in Markdown format, optimized for sharing with AI assistants.
+- **LLMs.txt Generation**: Generates an `llms.txt` index after builds for LLM-friendly site discovery.
 - **Customizable Styling**: Includes optional inline CSS to maintain consistent styling across your documentation, aligning with themes like [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).
 
 ## 🛠️ Installation
@@ -134,6 +135,7 @@ Both modes support the same configuration options:
 | `add_json_ld`       | bool | `False` | Add JSON-LD structured data      |
 | `add_css`           | bool | `True`  | Include inline CSS styles        |
 | `add_copy_llm`      | bool | `True`  | Add "Copy for LLM" button        |
+| `add_llms_txt`      | bool | `True`  | Generate an `llms.txt` index     |
 
 ## 🧩 How It Works
 


### PR DESCRIPTION
## Summary
- replaces the broken Zensical homepage link with the current official site
- documents the existing default `add_llms_txt` option
- adds the corresponding LLMs.txt feature bullet

## Validation
- git diff --check
- lychee README.md --no-progress --accept 200,204,206,301,302,429 --exclude 'https://twitter.com/ultralytics'
- python -m py_compile plugin/main.py plugin/postprocess.py plugin/processor.py plugin/utils.py

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📚 This PR updates the MkDocs Ultralytics plugin documentation to highlight new `llms.txt` generation support and fixes the Zensical website link.

### 📊 Key Changes
- Added **`LLMs.txt Generation`** to the README feature list 🤖
- Documented a new configuration option:
  - `add_llms_txt` | bool | `True` | Generate an `llms.txt` index
- Clarified that the plugin can now generate an **`llms.txt` index after site builds** for LLM-friendly discovery
- Fixed the **Zensical** link in the README from `.com` to `.org` 🔗

### 🎯 Purpose & Impact
- Makes the plugin’s **LLM-oriented capabilities more visible** to users and contributors
- Helps documentation sites become easier for **AI tools and assistants to discover and consume** 🤝
- Improves README accuracy so users can better understand available options before configuring the plugin
- Fixing the Zensical link prevents confusion and improves the overall documentation quality ✅