### PR TITLE
Simplify Slack notification messages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,16 +125,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
-      - name: Extract PR Details
+      - name: Get release title
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.check.outputs.current_tag }}
         run: |
-          PR_JSON=$(gh pr list --search "${GITHUB_SHA}" --state merged --json number,title --jq '.[0]')
-          PR_NUMBER=$(echo "${PR_JSON}" | jq -r '.number')
-          PR_TITLE=$(echo "${PR_JSON}" | jq -r '.title' | sed 's/"/\\"/g')
-          echo "PR_NUMBER=${PR_NUMBER}" >> "${GITHUB_ENV}"
-          echo "PR_TITLE=${PR_TITLE}" >> "${GITHUB_ENV}"
+          TITLE=$(gh release view "$TAG" --json name -q .name 2>/dev/null | tr -d '\n\r"\\') || TITLE=""
+          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
         if: needs.publish.result == 'success' && github.event_name == 'push'
         uses: slackapi/slack-github-action@v3.0.3
@@ -142,7 +141,7 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "<!channel> GitHub Actions success for ${{ github.workflow }} ✅\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* NEW `${{ github.repository }} ${{ needs.check.outputs.current_tag }}` pip package published 😃\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ✅ `${{ github.repository }}` ${{ steps.release.outputs.title || needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.current_tag }}|*Release*>  ·  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"
       - name: Notify Failure
         if: needs.publish.result != 'success'
         uses: slackapi/slack-github-action@v3.0.3
@@ -150,4 +149,4 @@ jobs:
           webhook-type: incoming-webhook
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_YOLO }}
           payload: |
-            text: "<!channel> GitHub Actions error for ${{ github.workflow }} ❌\n\n\n*Repository:* https://github.com/${{ github.repository }}\n*Action:* https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}\n*Author:* ${{ github.actor }}\n*Event:* ${{ github.event_name }}\n*Job Status:* ${{ job.status }}\n*Pull Request:* <https://github.com/${{ github.repository }}/pull/${{ env.PR_NUMBER }}> ${{ env.PR_TITLE }}\n"
+            text: "<!subteam^S082BPCRAJ3> *${{ github.workflow }}* ❌ `${{ github.repository }}` ${{ needs.check.outputs.current_tag }}  <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|*Run*>"


### PR DESCRIPTION
Replaces the verbose multi-line Slack notifications with a single dense line — bold workflow name, status emoji, `${{ github.repository }}`, and a *Run* backlink — matching the format used in `ultralytics/portal`.

- Scopes the broad `<!channel>` ping down to `@yolo-team` to cut company-wide notification noise.
- Publish notifications surface the GitHub release title + *Release* link; the now-dead `Extract PR Details` step is replaced by a lean `gh release view` step.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
🔔 This PR simplifies the release notification workflow by switching Slack messages from PR-based details to release-based details in the GitHub Actions publish pipeline.

### 📊 Key Changes
- Replaced the old **“Extract PR Details”** step with a new **“Get release title”** step.
- Removed the need to:
  - check out the repository with `actions/checkout`
  - search merged PRs by commit SHA
  - parse PR number and PR title with `jq`
- Added logic to fetch the **GitHub release title** directly using `gh release view` and the current tag.
- Updated **Slack success notifications** to:
  - mention a specific Slack subteam instead of `@channel`
  - show the workflow name, repository, and release title or tag
  - include direct links to the **release page** and **workflow run**
- Updated **Slack failure notifications** to use the same shorter, cleaner format focused on the tag and run link.

### 🎯 Purpose & Impact
- ✅ **More reliable notifications**: release alerts now reflect the actual published release instead of trying to infer details from a merged PR.
- ⚡ **Simpler workflow**: fewer steps and no PR parsing reduce maintenance and chances of failure.
- 🧹 **Cleaner Slack messages**: notifications are shorter, easier to read, and link directly to the most relevant pages.
- 🎯 **Better team targeting**: using a Slack subteam mention helps notify the right group without broadly pinging everyone.
- 🚀 **Improved release visibility**: users and maintainers can quickly jump from Slack to the published release or workflow run.