### PR TITLE
Linkify PR numbers in publish Slack notifications

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,6 +133,7 @@ jobs:
           TAG: ${{ needs.check.outputs.current_tag }}
         run: |
           TITLE=$(gh release view "$TAG" --json name -q .name 2>/dev/null | tr -d '\n\r"\\') || TITLE=""
+          TITLE=$(printf '%s' "$TITLE" | sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g")
           echo "title=$TITLE" >> "$GITHUB_OUTPUT"
       - name: Notify Success
         if: needs.publish.result == 'success' && github.event_name == 'push'


### PR DESCRIPTION
Turns the `#<number>` PR reference inside the GitHub release title into a clickable link to the PR in the **Publish to PyPI** success notification, e.g. `(#24965)` → [`#24965`](pull link).

- One line added to the existing `Get release title` step: `sed -E "s@#([0-9]+)@<https://github.com/$GH_REPO/pull/\1|#\1>@g"`.
- No-ops on titles without a `#<number>`; `/pull/N` auto-redirects to `/issues/N` if it ever isn't a PR.
- All Slack `text:` payload lines are unchanged — the link is built at the source where the title is fetched.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
This PR improves release notifications by automatically converting pull request references like `#123` in release titles into clickable GitHub links 🔗

### 📊 Key Changes
- Updated the GitHub Actions workflow in `.github/workflows/publish.yml`.
- Added a step that scans the release title for PR references in the `#123` format.
- Replaces those references with direct links to the matching pull request in the current repository.
- The change happens before the success notification is sent ✅

### 🎯 Purpose & Impact
- Makes release notifications more useful by turning plain PR numbers into clickable links 👀
- Helps readers quickly open the related pull request without manually searching for it.
- Improves traceability and readability of release announcements for developers and broader audiences alike.
- Small workflow-only change, so impact is low-risk and focused on better automation and communication 🚀