### PR TITLE
Bump actions/setup-python from v6 to v7 in /.github/workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       previous_tag: ${{ steps.check_pypi.outputs.previous_tag }}
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main
@@ -73,7 +73,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main
@@ -111,7 +111,7 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.x"
       - uses: ultralytics/actions/setup-uv@main


### PR DESCRIPTION
Bump actions/setup-python from v6 to v7 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the documentation publishing workflow to use the latest Python setup action. ⚙️

### 📊 Key Changes

- Upgraded `actions/setup-python` from `v6` to `v7`.
- Applied the update across all three publishing workflow jobs in `.github/workflows/publish.yml`.
- No changes were made to the Python version or other workflow steps.

### 🎯 Purpose & Impact

- Keeps the CI/CD workflow aligned with the latest GitHub Actions tooling. ✅
- Improves compatibility, maintenance, and access to updates from `actions/setup-python`.
- Helps ensure reliable documentation publishing without changing the existing release process. 🚀