### PR TITLE
Queue publish runs and retry PyPI upload failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: false
+  queue: max
 
 jobs:
   check:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ on:
         type: boolean
         description: Publish to PyPI
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   check:
     if: github.repository == 'ultralytics/mkdocs' && github.actor == 'glenn-jocher' && github.ref == 'refs/heads/main'
@@ -100,8 +104,20 @@ jobs:
           name: dist
           path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1
+        id: publish
+        continue-on-error: true
         with:
           skip-existing: true # tolerate recovery re-runs after partial failures
+      - name: Clean partial attestations # leftover *.publish.attestation files make the retry fail pre-existence checks
+        if: steps.publish.outcome == 'failure'
+        run: |
+          rm -f dist/*.publish.attestation
+          sleep 30
+      - name: Retry publish # transient sigstore/Rekor or PyPI network failures
+        if: steps.publish.outcome == 'failure'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
   sbom:
     needs: [check, build, publish]


### PR DESCRIPTION
## Summary

- Serialize publish workflows with `queue: max`, preserving up to 100 pending releases.
- Retry `pypa/gh-action-pypi-publish` once after transient Sigstore/Rekor or PyPI failures.
- Remove partial publish attestations and wait briefly before retrying; retain `skip-existing` for partial-upload recovery.

This applies the resilience fix from [ultralytics/ultralytics#25331](https://github.com/ultralytics/ultralytics/pull/25331) consistently across active Ultralytics PyPI publishers.

Deleted: nothing — GitHub owns workflow scheduling, and the external PyPI action exposes no retry input while retaining partial attestation files after failure.

## Validation

- `git diff --check`
- GitHub's documented `concurrency.queue: max` syntax; local actionlint 1.7.12 predates this property

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Improves PyPI publishing reliability by preventing overlapping releases and automatically retrying transient failures. 🚀

### 📊 Key Changes

- Added workflow concurrency controls to queue publishing runs and avoid conflicting releases.
- Updated the PyPI publish step to:
  - Tolerate an initial failure.
  - Remove partial attestation files left behind by failed attempts.
  - Wait briefly before retrying the upload.
  - Skip packages that already exist on PyPI.
- Ensured the SBOM job continues to depend on the completed publish job.

### 🎯 Purpose & Impact

- Reduces failed releases caused by temporary Sigstore, Rekor, or PyPI network issues. 🔄
- Makes recovery runs safer after partially completed uploads.
- Prevents concurrent publishing workflows from interfering with one another.
- Improves the reliability of package releases without requiring manual intervention. ✅