### PR TITLE
Restore canonical AGENTS.md sections

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,33 +2,31 @@
 
 This file provides guidance to AI coding agents (Claude Code, etc.) when working with code in this repository. CLAUDE.md is a symlink to this file.
 
+`mkdocs-ultralytics-plugin` (AGPL-3.0) is the MkDocs plugin behind [docs.ultralytics.com](https://docs.ultralytics.com): it adds SEO metadata, social cards, JSON-LD structured data, git author and date footers, a "Copy for LLM" button, and `llms.txt` generation to built documentation.
+
 ## Core Principles (CRITICAL)
 
-Respecting these principles is critical for every PR.
+**Less is more. The simplest solution is the best solution.** The action hierarchy for every change: **Delete > Replace > Add**.
 
-**Less is more. The simplest solution is the best solution.**
+1. **Solve at the owner**: Put behavior in the code path that owns or observes it. For fixes, never guard a symptom with a staleness check, initialization flag, skip-first-call branch, or `try/except` around broken logic; relocate the trigger and delete the wrong path. For features, extend the existing owner rather than creating a parallel abstraction.
+2. **Search and reuse first**: Search the whole repository before creating a feature, component, helper, workflow, or utility. Reuse or adapt what exists, consolidate in-scope duplication in the shared owner, and delete duplicate paths. Three similar lines beat a helper nobody else calls.
+3. **Delete and modify existing code before creating new code**: Bugfixes are net-negative by default unless deletion and relocation are demonstrably impossible. A new file must first prove it cannot fit cleanly in an existing owner.
+4. **Keep scope minimal**: Implement only the simplest complete solution. Avoid impossible-state handling, speculative flags, compatibility shims, policy scaffolding, and unrelated cleanup. Tests are out of scope by default — rely on existing coverage and focused validation; only an uncovered, high-risk regression path justifies minimal new test code.
+5. **Ship zero-regression, production-ready changes**: Understand what you remove instead of retaining broken code as insurance. Remove unused imports, functions, types, files, and comments; run relevant cleanup checks; and thoroughly debug and validate the changed owner. Do not break existing features or workflows unless the PR intentionally removes them with evidence.
 
-The action hierarchy for every change: **Delete > Replace > Add**. The best code change is a deletion. The second best is modifying what exists. Adding new code is the last resort.
+**Review gate:** for every addition, the reviewer decides whether deleting or changing existing code would have fixed the problem instead — if it would, that is a blocking finding. A missing or thin PR description is never itself a finding.
 
-1. **Minimal**: The simplest solution that works. Do not over-engineer, over-abstract, or add code just in case. Three similar lines beat a premature abstraction. Avoid error handling for impossible states, feature flags, compatibility shims, or policy scaffolding unless they are truly required.
-2. **Solve at the source**: Do not hack fixes. Solve problems at their root. If something is broken, fix or remove the broken thing. Never patch over a broken abstraction, add workarounds, or add synchronization code for state that should not be duplicated.
-3. **Delete ruthlessly**: When replacing code, delete what it replaced. Remove unused imports, functions, types, files, and commented-out code. Git preserves history. Run the repo's relevant dead-code or cleanup check when available.
-4. **Replace > Add**: Modify existing code over adding new code. Edit existing files, extend existing components or functions with minimal parameters, and reuse existing utilities. If creating a new file, first prove it cannot fit cleanly in an existing file.
-5. **Check existing**: Search the entire repo before creating anything new. If a feature, component, helper, responder, workflow, or utility already solves a similar problem, reuse or adapt it and delete the duplicate path.
-6. **Deduplicate**: Do not duplicate existing code when updating the repo. Consolidate or refactor duplicates you find when it is in scope and low risk.
-7. **Zero Regression**: Do not break existing features or workflows unless the PR intentionally removes them with evidence.
-8. **Production ready**: All changes must be thoroughly debugged, validated, and production ready.
-
-**When fixing bugs, ask: "What can I delete?" before "What can I replace?" before "What should I add?"**
+NEVER push to `main`. NEVER force push. Always start work in a new git worktree (`git worktree add`) on a feature branch and open a PR — never edit the primary checkout directly, it may hold in-flight work.
 
 ## PR Workflow
 
 After opening a PR:
 
 1. Wait for the automated PR review and auto-format commit from Ultralytics Actions (`format.yml`), then pull and address every finding.
-2. Launch an independent adversarial review agent with cold context (just the PR diff and this file) to hunt for bugs, regressions, and Core Principles violations — use the Codex CLI, one fresh `codex exec` run per round. Fix, push, and repeat until a fresh run reports LGTM.
-3. Never fight other commits: Ultralytics Actions pushes auto-format and header commits, and multiple users may work on the same PR. `git pull --rebase` before pushing; never force-push, reset, or revert commits you did not author.
-4. After the PR merges, clean up: remove local worktrees and branches for it, then `git checkout main && git pull`.
+2. Review the full diff in-session against the Core Principles, performance, and the review gate above, then batch the fixes into one commit and push. After each round of bot or human commits, pull and resume the same reviewer on `<last-reviewed-sha>..HEAD` plus anything that delta could have invalidated. Repeat until the local head matches the live head.
+3. Hand off or merge only on a clean final pass: one cold full-diff review returning LGTM with no findings, on a head that is still live at merge time.
+4. Never fight other commits: Ultralytics Actions pushes auto-format and header commits, and multiple users may work on the same PR. `git pull --rebase` before pushing; never reset or revert commits you did not author.
+5. After the PR merges, clean up: remove local worktrees and branches for it, then `git checkout main && git pull`.
 
 ## Commands
 
@@ -37,7 +35,7 @@ After opening a PR:
 uv pip install -e ".[dev]"
 
 # Lint and format, mirroring CI (.github/workflows/format.yml runs ultralytics/actions@main; there is no local ruff/lint config — that action is the source of truth for these flags)
-uvx ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA --target-version py39 --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012 .
+uvx ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA --target-version py38 --ignore BLE001,D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012,S110 .
 uvx ruff format --line-length 120 .
 uvx --from ultralytics-actions ultralytics-actions-format-python-docstrings .
 


### PR DESCRIPTION
Aligns AGENTS.md with the canonical version maintained in `ultralytics/ultralytics`.

- Replaces a locally rewritten 8-item Core Principles list with the canonical 5 principles, Review gate, and the NEVER-push-to-main worktree paragraph, which the local copy had dropped entirely.
- Restores the canonical 5-step PR Workflow; the local copy had collapsed steps 2 and 3 into a single tool-specific instruction.
- Adds the repo-specific intro paragraph that every Ultralytics AGENTS.md carries between the standard header line and Core Principles.
- The documented lint command claimed to mirror `ultralytics/actions` but used `--target-version py39`; the action targets `py38` and also ignores `BLE001` and `S110`. Since `requires-python` here is `>=3.8`, the documented command would have let pyupgrade emit 3.9-only syntax. Corrected to match the action.

Repo-specific Commands, Architecture, and Conventions sections are otherwise unchanged.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

Updates the contributor guidance for the Ultralytics MkDocs plugin with clearer development principles, review procedures, and current formatting commands. 🛠️

### 📊 Key Changes

- Documented the purpose and capabilities of `mkdocs-ultralytics-plugin`, including SEO metadata, social cards, JSON-LD, git footers, “Copy for LLM,” and `llms.txt` generation.
- Refined the core development principles to emphasize:
  - Solving issues at their source.
  - Searching for and reusing existing code.
  - Deleting or modifying code before adding new abstractions.
  - Keeping changes minimal and regression-free.
- Added a formal review gate requiring reviewers to consider whether existing code could be changed or removed instead of adding new code.
- Updated repository workflow guidance:
  - Always use a new Git worktree and feature branch.
  - Perform full-diff reviews and cold final reviews before merging.
  - Continue reviewing changes after bot or human commits.
- Updated Ruff commands to target Python 3.8 and include revised lint rule selections and exclusions.

### 🎯 Purpose & Impact

- 🧭 Gives AI agents and contributors clearer, more consistent instructions for making focused changes.
- 🧹 Encourages simpler implementations, less duplication, and removal of obsolete code.
- 🔍 Strengthens review practices to catch regressions and violations before merging.
- ⚙️ Aligns local linting and formatting instructions more closely with the repository’s current CI behavior.
- 🤝 Improves collaboration safety by reducing conflicts from direct edits, force pushes, or outdated review assumptions.