### PR TITLE
Remove dead setuptools package-data entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,5 @@ ultralytics = "plugin:MetaPlugin"  # executes the function `MetaPlugin` from thi
 [project.optional-dependencies]  # Optional
 dev = ["pytest"]
 
-[tool.setuptools]  # This is configuration specific to the `setuptools` build backend.
-package-data = { "sample" = ["*.yaml"] }
-
 [tool.setuptools.dynamic]
 version = {attr = "plugin.__version__"}


### PR DESCRIPTION
`pyproject.toml` carried `package-data = { "sample" = ["*.yaml"] }` from the Ultralytics Python template. There is no `sample` package in this repo (the only package is `plugin/`) and no YAML ships inside it, so the entry matched nothing. Its `[tool.setuptools]` table held nothing else, so both go.

Verified by building the wheel before and after: identical contents, all 5 `plugin/` files present in each, so setuptools auto-discovery covers what the explicit table was not doing.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🧹 Removes obsolete setuptools package-data configuration from the project metadata.

### 📊 Key Changes

- Deleted the `[tool.setuptools]` configuration block from `pyproject.toml`.
- Removed the unused package-data declaration for YAML files in the `sample` package.
- Kept dynamic version loading from `plugin.__version__` unchanged.

### 🎯 Purpose & Impact

- Simplifies the project configuration and removes unnecessary packaging metadata.
- Reduces the risk of maintaining stale or irrelevant package-data settings.
- Has minimal user-facing impact, with no expected changes to the plugin’s runtime behavior.